### PR TITLE
ItemStack and App-Background

### DIFF
--- a/nodes.lua
+++ b/nodes.lua
@@ -12,7 +12,7 @@ minetest.register_node("laptop:core_open", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
+	groups = {choppy=2, oddly_breakably_by_hand=2,  dig_immediate = 2, not_in_creative_inventory=1},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_on("laptop:core_open_on")
@@ -22,6 +22,9 @@ minetest.register_node("laptop:core_open", {
 		os:power_off()
 		os:set_infotext('MineTest Core')
 	end,
+	stack_max = 1,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
 	node_box = {
 		type = "fixed",
 		fixed = {
@@ -45,7 +48,7 @@ minetest.register_node("laptop:core_open_on", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_off("laptop:core_closed")
@@ -55,6 +58,9 @@ minetest.register_node("laptop:core_open_on", {
 		os:power_on()
 		os:set_infotext('MineTest Core')
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	on_receive_fields = function(pos, formname, fields, sender)
 		local os = laptop.os_get(pos)
 		os:receive_fields(fields, sender)
@@ -82,7 +88,7 @@ minetest.register_node("laptop:core_closed", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_off("laptop:core_open")
@@ -92,6 +98,9 @@ minetest.register_node("laptop:core_closed", {
 		os:power_off()
 		os:set_infotext('MineTest Core')
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	node_box = {
 		type = "fixed",
 		fixed = {
@@ -116,7 +125,7 @@ minetest.register_node("laptop:monitor_on", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:monitor_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_off("laptop:monitor_off")
@@ -126,6 +135,9 @@ minetest.register_node("laptop:monitor_on", {
 		os:power_on()
 		os:set_infotext('MT Desktop')
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	on_receive_fields = function(pos, formname, fields, sender)
 		local os = laptop.os_get(pos)
 		os:receive_fields(fields, sender)
@@ -156,11 +168,14 @@ minetest.register_node("laptop:monitor_off", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:monitor_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_on("laptop:monitor_on")
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)
 		os:power_off()
@@ -192,7 +207,7 @@ minetest.register_node("laptop:monitor2_on", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:monitor2_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_off("laptop:monitor2_off")
@@ -202,6 +217,9 @@ minetest.register_node("laptop:monitor2_on", {
 		os:power_on()
 		os:set_infotext('MT Desktop')
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	on_receive_fields = function(pos, formname, fields, sender)
 		local os = laptop.os_get(pos)
 		os:receive_fields(fields, sender)
@@ -236,11 +254,14 @@ minetest.register_node("laptop:monitor2_off", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	drop = "laptop:monitor2_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2},
+	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
 		os:power_on("laptop:monitor2_on")
 	end,
+	after_place_node = laptop.after_place_node,
+	after_dig_node = laptop.after_dig_node,
+	stack_max = 1,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)
 		os:power_off()

--- a/os.lua
+++ b/os.lua
@@ -67,3 +67,31 @@ function laptop.os_get(pos)
 	self.appdata.launcher = self.appdata.launcher or {}
 	return self
 end
+
+-----------------------------------------------------
+-- Hooks for node definition
+-----------------------------------------------------
+function laptop.after_place_node(pos, placer, itemstack, pointed_thing)
+	local appdata = minetest.deserialize(itemstack:get_meta():get_string("laptop_appdata"))
+	if appdata then
+		local os = laptop.os_get(pos)
+		os.appdata = appdata
+		os:save()
+	end
+end
+
+function laptop.after_dig_node(pos, oldnode, oldmetadata, digger)
+	local appdata = oldmetadata.fields['laptop_appdata']
+	if appdata then
+		local item_name = minetest.registered_items[oldnode.name].drop or oldnode.name
+		local inventory = digger:get_inventory()
+		for idx = inventory:get_size("main"), 1, -1 do
+			local stack = inventory:get_stack("main", idx)
+			if stack:get_name() == item_name and stack:get_meta():get_string("laptop_appdata") == "" then
+				stack:get_meta():set_string("laptop_appdata", appdata)
+				digger:get_inventory():set_stack("main", idx, stack)
+				break
+			end
+		end
+	end
+end

--- a/os.lua
+++ b/os.lua
@@ -58,8 +58,7 @@ end
 -- Get Operating system object
 -----------------------------------------------------
 function laptop.os_get(pos)
-	local self = {}
-	setmetatable(self, os_class)
+	local self = setmetatable({}, os_class)
 	self.__index = os_class
 	self.pos = pos
 	self.meta = minetest.get_meta(pos)


### PR DESCRIPTION
This PR contain 2 changes:
- Items are diggable (dig_immediate = 2 was missed), in case of digging the "Apps-data" is moved to ItemStack and restored if the laptop is placed again. Therefore the App-Size is set to 1 for now

- Background image is now an app attribute. Can be set at App-definition time (See launcher) or at Run-Time (See demo2). Of course the current image can be stored to the app:get_storage_ref() provided table ;-)