### PR TITLE
Important bugfix and next change

### DIFF
--- a/app_fw.lua
+++ b/app_fw.lua
@@ -5,10 +5,12 @@ app_class.__index = app_class
 
 function app_class:get_formspec()
 	if self.formspec_func then
-		return 'size[15,10]'..
-				'background[15,10;0,0;os_main2.png;true]'..
-				'bgcolor[#00000000;false]'..
-		self.formspec_func(self, self.os)
+		local app_result = self.formspec_func(self, self.os)
+		local formspec = 'size[15,10]'
+		if self.background_img then
+			formspec = formspec..'background[15,10;0,0;'..self.background_img..';true]'
+		end
+		return formspec..app_result
 	else
 		return ""
 	end
@@ -27,84 +29,27 @@ function app_class:get_storage_ref()
 	return self.os.appdata[self.name]
 end
 
-
---[[ ********** App API definition  ***********
-	* methods
-	app.formspec_func(app, os)
-	app.receive_fields_func(app, os, fields, sender)
-
-	* attributes
-	app.app_name - displayed string. If not given it is just a view, not listed in apps list
- ****************************************** ]]
-
-
 function laptop.register_app(name, def)
 	laptop.apps[name] = def
 end
 
 function laptop.get_app(name, os)
-	local app = laptop.apps[name]
-	if not app then
+	local template = laptop.apps[name]
+	if not template then
 		return
 	end
-	app = setmetatable(app, app_class)
+	local app = setmetatable(table.copy(template), app_class)
 	app.name = name
 	app.os = os
 	return app
 end
 
-------------------------------------------------------------------------
-laptop.register_app("launcher", {
---	app_name = "Main launcher", -- not in launcher list
-	formspec_func = function(app, os)
-		local i = 0
-		local out = ""
-		local appslist_sorted = {}
-		for name, def in pairs(laptop.apps) do
-			if def.app_name then
-				table.insert(appslist_sorted, {name = name, def = def})
-			end
-		end
-		table.sort(appslist_sorted, function(a,b) return a.name < b.name end)
-		for i, e in ipairs(appslist_sorted) do
-			out = out .. 'button['..2*i..',1;2,1;'..e.name..';'..e.def.app_name..']'
-		end
-		return out
-	end,
-	receive_fields_func = function(app, os, fields, sender)
-		for name, descr in pairs(fields) do
-			if laptop.apps[name] then
-				os:set_app(name)
-				break
-			end
-		end
-	end
-})
+-- load all apps
+local app_path = minetest.get_modpath('laptop')..'/apps/'
+local app_list = minetest.get_dir_list(app_path, false)
 
-laptop.register_app("demo1", {
-	app_name = "Demo App",
-	formspec_func = function(app, os)
-		return 'button[5,5;3,1;Back;Back to launcher]'
-	end,
-	receive_fields_func = function(app, os, fields, sender)
-		os:set_app("launcher")
+for _, file in ipairs(app_list) do
+	if file:sub(-8) == '_app.lua' then
+		dofile(app_path..file)
 	end
-})
-
-laptop.register_app("demo2", {
-	app_name = "Demo App 2",
-	formspec_func = function(app, os)
-		local data = app:get_storage_ref()
-		data.counter = data.counter or 1
-		return 'button[3,1;5,1;count;Click: '..data.counter..']'..
-				'button[3,3;5,1;back;Back to launcher]'
-	end,
-	receive_fields_func = function(app, os, fields, sender)
-		if fields.count then
-			local data = app:get_storage_ref()
-			data.counter = data.counter + 1
-		elseif fields.back then
-			os:set_app("launcher")
-		end
-	end
-})
+end

--- a/apps/launcher_app.lua
+++ b/apps/launcher_app.lua
@@ -1,0 +1,28 @@
+
+laptop.register_app("launcher", {
+--	app_name = "Main launcher", -- not in launcher list
+	background_img = "os_main2.png",
+	formspec_func = function(app, os)
+		local i = 0
+		local out = ""
+		local appslist_sorted = {}
+		for name, def in pairs(laptop.apps) do
+			if def.app_name then
+				table.insert(appslist_sorted, {name = name, def = def})
+			end
+		end
+		table.sort(appslist_sorted, function(a,b) return a.name < b.name end)
+		for i, e in ipairs(appslist_sorted) do
+			out = out .. 'button['..2*i..',1;2,1;'..e.name..';'..e.def.app_name..']'
+		end
+		return out
+	end,
+	receive_fields_func = function(app, os, fields, sender)
+		for name, descr in pairs(fields) do
+			if laptop.apps[name] then
+				os:set_app(name)
+				break
+			end
+		end
+	end
+})

--- a/apps/stickynote_app.lua
+++ b/apps/stickynote_app.lua
@@ -1,0 +1,19 @@
+laptop.register_app("stickynote", {
+	app_name = "Sticky note pad",
+	formspec_func = function(app, os)
+		local data = app:get_storage_ref()
+		data.text = data.text or ""
+
+		return "textarea[1,1;13,9;text;Sticky Note Pad;"..minetest.formspec_escape(data.text).."]"..
+				'button[1,9;3,1;back;Back]'
+	end,
+	receive_fields_func = function(app, os, fields, sender)
+		if fields.text then
+			local data = app:get_storage_ref()
+			data.text = fields.text
+		end
+		if fields.back then
+			os:set_app("launcher")
+		end
+	end
+})

--- a/demo_apps.lua
+++ b/demo_apps.lua
@@ -1,0 +1,32 @@
+
+laptop.register_app("demo1", {
+	app_name = "Demo App",
+	formspec_func = function(app, os)
+		return 'button[5,5;3,1;Back;Back to launcher]'
+	end,
+	receive_fields_func = function(app, os, fields, sender)
+		os:set_app("launcher")
+	end
+})
+
+laptop.register_app("demo2", {
+	app_name = "Demo App 2",
+	formspec_func = function(app, os)
+		local data = app:get_storage_ref()
+		data.counter = data.counter or 1
+
+		if data.counter % 2 == 0 then
+			app.background_img = "background1.png"
+		end
+		return 'button[3,1;5,1;count;Click: '..data.counter..']'..
+				'button[3,3;5,1;back;Back to launcher]'
+	end,
+	receive_fields_func = function(app, os, fields, sender)
+		if fields.count then
+			local data = app:get_storage_ref()
+			data.counter = data.counter + 1
+		elseif fields.back then
+			os:set_app("launcher")
+		end
+	end
+})

--- a/init.lua
+++ b/init.lua
@@ -3,3 +3,6 @@ laptop = {}
 dofile(minetest.get_modpath('laptop')..'/app_fw.lua')
 dofile(minetest.get_modpath('laptop')..'/os.lua')
 dofile(minetest.get_modpath('laptop')..'/nodes.lua')
+
+-- uncomment this line to disable demo apps in production
+dofile(minetest.get_modpath('laptop')..'/demo_apps.lua')


### PR DESCRIPTION
I seen during development I forgot to commit last app_fw.lua to github

Next changes in addition:
demo-apps moved to demo_apps.lua, this way the demos could be enabled/disabled by commenting in or out 1 line in init.lua

folder "apps" created, laucher moved "apps/launcher_app.lua"
new app "stickynote" created (simple text editor)
The framework reads all files selecting apps/*_app.lua and process them at init time. So each app should be in own file for now. All files does not match _app.lua suffix are ignored.