### PR TITLE
OS enhancements / Launcher integration

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ Usable from node functions, from apps or outsite
 - `os:save()` - Store all app-data to nodemeta. Called mostly internally so no explicit call necessary
 - `os:set_app(appname)` - Start/Enable/navigate to appname. If no appname given the launcher is called
 - `os:receive_fields(fields, sender)` - Should be called from node.on_receive_fields to get the apps interactive
-
+- `os.custom_launcher` - Replacement for default "launcher" app. Can be set/changed in node constructor or anytime at runtime
 
 ## App Definition
 `laptop.register_app(internal_shortname, { definitiontable })` - add a new app or view

--- a/API.md
+++ b/API.md
@@ -12,7 +12,9 @@ Usable from node functions, from apps or outsite
 `local os = laptop.os_get(pos)` - Get the Operating system object. pos is the node position
 
 - `os:power_on(new_node_name)` - Activate the app "launcher" and if given swap node to new_node_name
+- `os:resume(new_node_name)` - Restore the last running app after power_off. if given swap node to new_node_name
 - `os:power_off(new_node_name)` - Remove the formspec and if given swap node to new_node_name
+- `os:swap_node(new_node_name)`- Swap the node only without any changes on OS
 - `os:set_infotext(infotext)` - Set the mouseover infotext for laptop node
 - `os:save()` - Store all app-data to nodemeta. Called mostly internally so no explicit call necessary
 - `os:set_app(appname)` - Start/Enable/navigate to appname. If no appname given the launcher is called

--- a/API.md
+++ b/API.md
@@ -33,4 +33,5 @@ Usable from node functions, from apps or outsite
 ## App Object
 `local app = laptop.get_app(internal_shortname, os)` - Give the app object internal_shortname, connected to given os. Not necessary in formspec_func or receive_fields_func because given trough interface
 - `data = app:get_storage_ref()` - Returns a "persitant" data table that means the data in this table is not lost between formspec_func, receive_fields_func, apps-switch or on/off.
+- `app:sync_storage()` - Store internal data (eg. background_img) to app storage
 - `app.background_img` - Background image from definition. Can be changed at runtime

--- a/app_fw.lua
+++ b/app_fw.lua
@@ -22,6 +22,19 @@ function app_class:receive_fields(fields, sender)
 	end
 end
 
+function app_class:sync_storage()
+	if self.background_img then
+		local data = self:get_storage_ref()
+		data._background_img = self.background_img
+	elseif self.os.appdata[self.name] then
+		self.os.appdata[self.name]._background_img = self.background_img
+		-- remove table if empty
+		if not next(self.os.appdata[self.name]) then
+			self.os.appdata[self.name] = nil
+		end
+	end
+end
+
 function app_class:get_storage_ref()
 	if not self.os.appdata[self.name] then
 		self.os.appdata[self.name] = {}
@@ -41,6 +54,9 @@ function laptop.get_app(name, os)
 	local app = setmetatable(table.copy(template), app_class)
 	app.name = name
 	app.os = os
+	if os.appdata[name] then
+		app.background_img = os.appdata[name]._background_img or app.background_img
+	end
 	return app
 end
 

--- a/demo_apps.lua
+++ b/demo_apps.lua
@@ -4,10 +4,12 @@ laptop.register_app("demo1", {
 	app_icon = "setting_wrench.png",
 	app_info = "The first and simple demo app",
 	formspec_func = function(app, os)
-		return 'button[5,5;3,1;Back;Back to launcher]'
+		return 'button[5,5;3,1;back;Back to launcher]'
 	end,
 	receive_fields_func = function(app, os, fields, sender)
-		os:set_app("launcher")
+		if fields.back then
+			os:set_app("launcher")
+		end
 	end
 })
 

--- a/nodes.lua
+++ b/nodes.lua
@@ -15,7 +15,7 @@ minetest.register_node("laptop:core_open", {
 	groups = {choppy=2, oddly_breakably_by_hand=2,  dig_immediate = 2, not_in_creative_inventory=1},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
-		os:power_on("laptop:core_open_on")
+		os:resume("laptop:core_open_on")
 	end,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)

--- a/nodes.lua
+++ b/nodes.lua
@@ -95,6 +95,7 @@ minetest.register_node("laptop:core_closed", {
 	end,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)
+--		os.custom_launcher = 'stickynote'
 		os:power_off()
 		os:set_infotext('MineTest Core')
 	end,

--- a/nodes.lua
+++ b/nodes.lua
@@ -172,6 +172,10 @@ minetest.register_node("laptop:monitor_off", {
 	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
 	on_punch = function (pos, node, puncher)
 		local os = laptop.os_get(pos)
+		-- change lauchher background - swap background for all instances on punch
+		local app = laptop.get_app("launcher", os)
+		app.background_img = "os_main.png"
+		app:sync_storage()
 		os:power_on("laptop:monitor_on")
 	end,
 	after_place_node = laptop.after_place_node,
@@ -179,6 +183,10 @@ minetest.register_node("laptop:monitor_off", {
 	stack_max = 1,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)
+		-- change lauchher background
+		local app = laptop.get_app("launcher", os)
+		app.background_img = "os_main.png"
+		app:sync_storage()
 		os:power_off()
 		os:set_infotext('MT Desktop')
 	end,
@@ -215,6 +223,9 @@ minetest.register_node("laptop:monitor2_on", {
 	end,
 	on_construct = function(pos)
 		local os = laptop.os_get(pos)
+		local app = laptop.get_app("launcher", os)
+		app.background_img = "os_main.png"
+		app:sync_storage()
 		os:power_on()
 		os:set_infotext('MT Desktop')
 	end,

--- a/os.lua
+++ b/os.lua
@@ -4,22 +4,33 @@
 local os_class = {}
 os_class.__index = os_class
 
--- Power on the system / initialize formspec and so
+-- Swap the node
+function os_class:swap_node(new_node_name)
+	local node = minetest.get_node(self.pos)
+	node.name = new_node_name
+	minetest.swap_node(self.pos, node)
+end
+
+-- Power on the system and start the launcher
 function os_class:power_on(new_node_name)
 	if new_node_name then
-		local node = minetest.get_node(self.pos)
-		node.name = new_node_name
-		minetest.swap_node(self.pos, node )
+		self:swap_node(new_node_name)
 	end
-	self:set_app("launcher") -- allways start with launcher after power on
+	self:set_app("launcher")
+end
+
+-- Power on the system / and resume last running app
+function os_class:resume(new_node_name)
+	if new_node_name then
+		self:swap_node(new_node_name)
+	end
+	self:set_app(self.appdata.launcher.current_app)
 end
 
 -- Power off the system
 function os_class:power_off(new_node_name)
 	if new_node_name then
-		local node = minetest.get_node(self.pos)
-		node.name = new_node_name
-		minetest.swap_node(self.pos, node )
+		self:swap_node(new_node_name)
 	end
 	self.meta:set_string('formspec', "")
 end

--- a/os.lua
+++ b/os.lua
@@ -33,6 +33,7 @@ function os_class:power_off(new_node_name)
 		self:swap_node(new_node_name)
 	end
 	self.meta:set_string('formspec', "")
+	self:save()
 end
 
 -- Set infotext for system
@@ -41,22 +42,25 @@ function os_class:set_infotext(infotext)
 end
 
 function os_class:save()
+	self.appdata.launcher.custom = self.custom_launcher
 	self.meta:set_string('laptop_appdata', minetest.serialize(self.appdata))
 end
 
 -- Set infotext for system
 function os_class:set_app(appname)
-	if not appname then
-		appname = "launcher"
+	local name = appname or "launcher"
+
+	if name == "launcher" and self.custom_launcher then
+		name = self.custom_launcher
 	end
-	self.appdata.launcher.current_app = appname
-	local app = laptop.get_app(appname, self)
+	self.appdata.launcher.current_app = name
+	local app = laptop.get_app(name, self)
 	self.meta:set_string('formspec', app:get_formspec())
 	self:save()
 end
 
 function os_class:receive_fields(fields, sender)
-	local appname = self.appdata.launcher.current_app or "launcher"
+	local appname = self.appdata.launcher.current_app or self.custom_launcher or "launcher"
 	local app = laptop.get_app(appname, self)
 	app:receive_fields(fields, sender)
 	if self.appdata.launcher.current_app == appname then
@@ -75,6 +79,7 @@ function laptop.os_get(pos)
 	self.meta = minetest.get_meta(pos)
 	self.appdata = minetest.deserialize(self.meta:get_string('laptop_appdata')) or {}
 	self.appdata.launcher = self.appdata.launcher or {}
+	self.custom_launcher = self.appdata.launcher.custom
 	return self
 end
 


### PR DESCRIPTION
- Fixed the bug in demo1 (exit on formspec close)
- Added resume() usable instead of power_on() - last app is still running in this case
- Added support for custom launcher. That means any other app can be started automatically on specific hardware
- Set "os_main.png" as background for laptop:monitor - with enhancements to get it working