### PR TITLE
Add laptop.register_hardware() and moved all laptops to this new node

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,25 @@
 # Laptop Mod API
 
-## Node creator helpers
+## Add new hardware nodes
+`laptop.register_hardware(name, hwdef)`
+- `name` - Item name (prefix) The created node names are name_variant
+- `hwdef.description`  -  Computer item name
+- `hwdef.infotext` - Text shown if node is pointed
+- `hwdef.sequence = { "variant_1_name", "variant_2_name", "variant_3_name" }` On punch swaps sequence. the first variant is in creative inventory
+- `hwdef.custom_launcer` - optional - custom launcher name
+- `hwdef.custom_theme` -  optional - custom initial theme name
+- `hwdef.node_defs = {
+		variant_1_name = {
+			hw_state =  "resume", "power_on" or "power_off", -- Hardware state
+			--node 1 definiton
+		},
+		variant_2_name = {
+			hw_state =  "resume", "power_on" or "power_off", -- Hardware state
+			--node 2 definiton
+		},
+	}` - A list for node definitions for each variant. with hw_state parameter for OS-initialization
+
+
 - `laptop.os_get(pos)` - Get an OS object. Usefull in on_construct or on_punch to initialize or do anything with OS
   Needed in on_receive_fields to be able to call os:receive_fields(fields, sender) for interactive apps
 - `laptop.after_place_node` / `laptop.after_dig_node` - (optional) can be used directly for node definition. Move laptop apps data to ItemStack if digged and restored back if placed again. So you can take along your laptop. Note: you need to set `stack_max = 1` because the data can be stored per stack only, not per item.

--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,7 @@ laptop = {}
 dofile(minetest.get_modpath('laptop')..'/themes.lua')
 dofile(minetest.get_modpath('laptop')..'/app_fw.lua')
 dofile(minetest.get_modpath('laptop')..'/os.lua')
+dofile(minetest.get_modpath('laptop')..'/node_fw.lua')
 dofile(minetest.get_modpath('laptop')..'/nodes.lua')
 
 -- uncomment this line to disable demo apps in production

--- a/node_fw.lua
+++ b/node_fw.lua
@@ -1,0 +1,106 @@
+
+laptop.node_config = {}
+
+local function after_place_node(pos, placer, itemstack, pointed_thing)
+	local appdata = minetest.deserialize(itemstack:get_meta():get_string("laptop_appdata"))
+	if appdata then
+		local os = laptop.os_get(pos)
+		os.appdata = appdata
+		os.appdata.launcher = os.appdata.launcher or {}
+		os.appdata.os = os.appdata.os or {}
+		os:save()
+	end
+end
+
+local function after_dig_node(pos, oldnode, oldmetadata, digger)
+	local appdata = oldmetadata.fields['laptop_appdata']
+	if appdata then
+		local item_name = minetest.registered_items[oldnode.name].drop or oldnode.name
+		local inventory = digger:get_inventory()
+		for idx = inventory:get_size("main"), 1, -1 do
+			local stack = inventory:get_stack("main", idx)
+			if stack:get_name() == item_name and stack:get_meta():get_string("laptop_appdata") == "" then
+				stack:get_meta():set_string("laptop_appdata", appdata)
+				digger:get_inventory():set_stack("main", idx, stack)
+				break
+			end
+		end
+	end
+end
+
+local function on_construct(pos)
+	local os = laptop.os_get(pos)
+	local node = minetest.get_node(pos)
+	local hwdef = laptop.node_config[node.name]
+	os.custom_launcher = hwdef.custom_launcher
+	if hwdef.custom_theme then
+		os:set_theme(hwdef.custom_theme)
+	end
+	if hwdef.hw_state then
+		os[hwdef.hw_state](os)
+	else
+		os:power_off()
+	end
+	os:set_infotext(hwdef.hw_infotext)
+end
+
+local function on_punch(pos, node, puncher)
+	local os = laptop.os_get(pos)
+	local hwdef = laptop.node_config[node.name]
+	if hwdef.next_node then
+		local hwdef_next = laptop.node_config[hwdef.next_node]
+		if hwdef_next.hw_state then
+			os[hwdef_next.hw_state](os, hwdef.next_node)
+		else
+			os:swap_node(hwdef.next_node)
+			os:save()
+		end
+		os:set_infotext(hwdef_next.hw_infotext)
+	end
+end
+
+local function on_receive_fields(pos, formname, fields, sender)
+	local os = laptop.os_get(pos)
+	os:receive_fields(fields, sender)
+end
+
+function laptop.register_hardware(name, hwdef)
+	local default_nodename = name.."_"..hwdef.sequence[1]
+	for idx, variant in ipairs(hwdef.sequence) do
+		local nodename = name.."_"..variant
+		local def = table.copy(hwdef.node_defs[variant])
+		def.description = hwdef.description
+
+		-- drop the item visible in inventory
+		if def.groups then
+			def.groups = table.copy(def.groups)
+		else
+			def.groups = {choppy=2, oddly_breakably_by_hand=2,  dig_immediate = 2}
+		end
+		if nodename ~= default_nodename then
+			def.drop = default_nodename
+			def.groups.not_in_creative_inventory = 1
+		end
+
+		-- needed to transfer content to item if place or dig laptop
+		def.stack_max = 1
+		def.after_place_node = after_place_node
+		def.after_dig_node = after_dig_node
+		def.on_punch = on_punch
+		def.on_construct = on_construct
+		def.on_receive_fields = on_receive_fields
+		minetest.register_node(nodename, def)
+
+		-- set node configuration for hooks
+		laptop.node_config[nodename] = table.copy(hwdef)
+		for k,v in pairs(hwdef.node_defs[variant]) do
+			laptop.node_config[nodename][k] = v
+		end
+		local next_seq = hwdef.sequence[idx+1] or hwdef.sequence[1]
+		local next_node = name.."_"..next_seq
+		if next_node ~= nodename then
+			laptop.node_config[nodename].next_node = next_node
+		end
+	end
+end
+

--- a/nodes.lua
+++ b/nodes.lua
@@ -1,374 +1,251 @@
-minetest.register_node("laptop:core_open", {
+laptop.register_hardware("laptop:core", {
 	description = "MineTest Core",
-	tiles = {
-		"laptop_laptop_core_tp_off.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_laptop_core_rt.png",
-		"laptop_laptop_core_lt.png",
-		"laptop_laptop_core_bk.png",
-		"laptop_laptop_core_ft.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2,  dig_immediate = 2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:resume("laptop:core_open_on")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_off()
-		os:set_infotext('MineTest Core')
-	end,
-	stack_max = 1,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
-			{-0.4375, -0.375, 0.3125, 0.4375, 0.375, 0.4375}, -- NodeBox2
+	infotext = 'MineTest Core',
+	sequence = { "closed", "open", "open_on" },
+
+	node_defs = {
+		["open"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_laptop_core_tp_off.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_laptop_core_rt.png",
+				"laptop_laptop_core_lt.png",
+				"laptop_laptop_core_bk.png",
+				"laptop_laptop_core_ft.png"
+			},
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
+					{-0.4375, -0.375, 0.3125, 0.4375, 0.375, 0.4375}, -- NodeBox2
+				}
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+		},
+		["open_on"] = {
+			hw_state = "resume",
+			tiles = {
+				"laptop_laptop_core_tp.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_laptop_core_rt.png",
+				"laptop_laptop_core_lt.png",
+				"laptop_laptop_core_bk.png",
+				"laptop_laptop_core_ft_on.png"
+			},
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
+					{-0.4375, -0.375, 0.3125, 0.4375, 0.375, 0.4375}, -- NodeBox2
+				}
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+		},
+		["closed"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_laptop_core_bk_off.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_laptop_core_rt_off.png",
+				"laptop_laptop_core_lt_off.png",
+				"laptop_laptop_core_r_off.png",
+				"laptop_laptop_core_ft_off.png"
+			},
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
+					{-0.4375, -0.375, -0.4375, 0.4375, -0.25, 0.4375}, -- NodeBox2
+				}
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
 		}
 	}
 })
 
-minetest.register_node("laptop:core_open_on", {
-	description = "MineTest Core",
-	tiles = {
-		"laptop_laptop_core_tp.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_laptop_core_rt.png",
-		"laptop_laptop_core_lt.png",
-		"laptop_laptop_core_bk.png",
-		"laptop_laptop_core_ft_on.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:core_closed")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_on()
-		os:set_infotext('MineTest Core')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
-			{-0.4375, -0.375, 0.3125, 0.4375, 0.375, 0.4375}, -- NodeBox2
-		}
-	}
-})
-
-minetest.register_node("laptop:core_closed", {
-	description = "MineTest Core",
-	tiles = {
-		"laptop_laptop_core_bk_off.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_laptop_core_rt_off.png",
-		"laptop_laptop_core_lt_off.png",
-		"laptop_laptop_core_r_off.png",
-		"laptop_laptop_core_ft_off.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:core_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:core_open")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
---		os.custom_launcher = 'stickynote'
-		os:power_off()
-		os:set_infotext('MineTest Core')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.4375}, -- NodeBox1
-			{-0.4375, -0.375, -0.4375, 0.4375, -0.25, 0.4375}, -- NodeBox2
-		}
-	}
-})
-
-
-minetest.register_node("laptop:monitor_on", {
+laptop.register_hardware("laptop:monitor", {
 	description = "MT Desktop",
-	tiles = {
-		"laptop_monitor_core_bt.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_monitor_core_rt.png",
-		"laptop_monitor_core_lt.png",
-		"laptop_monitor_core_bk.png",
-		"laptop_monitor_core_ft_on.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:monitor_off")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_on()
-		os:set_infotext('MT Desktop')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.25, 0.4375, -0.4375, 0.25}, -- NodeBox4
-			{-0.125, -0.4375, -0.0625, 0.125, -0.375, 0.0625}, -- NodeBox7
-			{-0.4375, -0.375, -0.125, 0.4375, 0.375, 0.125}, -- NodeBox8
-			{-0.4375, -0.5, -0.5, 0.25, -0.4375, -0.3125}, -- NodeBox9
-			{0.3125, -0.5, -0.5, 0.4375, -0.4375, -0.3125}, -- NodeBox10
+	infotext = "MT Desktop",
+	sequence = { "off", "on"},
+	custom_theme = "red",
+	node_defs = {
+		["on"] = {
+			hw_state = "power_on",
+			tiles = {
+				"laptop_monitor_core_bt.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_monitor_core_rt.png",
+				"laptop_monitor_core_lt.png",
+				"laptop_monitor_core_bk.png",
+				"laptop_monitor_core_ft_on.png"
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.25, 0.4375, -0.4375, 0.25}, -- NodeBox4
+					{-0.125, -0.4375, -0.0625, 0.125, -0.375, 0.0625}, -- NodeBox7
+					{-0.4375, -0.375, -0.125, 0.4375, 0.375, 0.125}, -- NodeBox8
+					{-0.4375, -0.5, -0.5, 0.25, -0.4375, -0.3125}, -- NodeBox9
+					{0.3125, -0.5, -0.5, 0.4375, -0.4375, -0.3125}, -- NodeBox10
+				}
+			},
+		},
+		["off"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_monitor_core_bt.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_monitor_core_rt.png",
+				"laptop_monitor_core_lt.png",
+				"laptop_monitor_core_bk.png",
+				"laptop_monitor_core_ft.png"
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.25, 0.4375, -0.4375, 0.25}, -- NodeBox4
+					{-0.125, -0.4375, -0.0625, 0.125, -0.375, 0.0625}, -- NodeBox7
+					{-0.4375, -0.375, -0.125, 0.4375, 0.375, 0.125}, -- NodeBox8
+					{-0.4375, -0.5, -0.5, 0.25, -0.4375, -0.3125}, -- NodeBox9
+					{0.3125, -0.5, -0.5, 0.4375, -0.4375, -0.3125}, -- NodeBox10
+				}
+			}
 		}
 	}
 })
 
-minetest.register_node("laptop:monitor_off", {
-	description = "MT Desktop",
-	tiles = {
-		"laptop_monitor_core_bt.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_monitor_core_rt.png",
-		"laptop_monitor_core_lt.png",
-		"laptop_monitor_core_bk.png",
-		"laptop_monitor_core_ft.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_on("laptop:monitor_on")
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:set_theme("red")
-		os:power_off()
-		os:set_infotext('MT Desktop')
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.25, 0.4375, -0.4375, 0.25}, -- NodeBox4
-			{-0.125, -0.4375, -0.0625, 0.125, -0.375, 0.0625}, -- NodeBox7
-			{-0.4375, -0.375, -0.125, 0.4375, 0.375, 0.125}, -- NodeBox8
-			{-0.4375, -0.5, -0.5, 0.25, -0.4375, -0.3125}, -- NodeBox9
-			{0.3125, -0.5, -0.5, 0.4375, -0.4375, -0.3125}, -- NodeBox10
+laptop.register_hardware("laptop:monitor2", {
+	description = "MT Desktop 2.0",
+	infotext = "MT Desktop 2.0",
+	sequence = { "off", "on"},
+	node_defs = {
+		["on"] = {
+			hw_state = "power_on",
+			tiles = {
+				"laptop_monitor2_core_bt.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_monitor_core_rt.png",
+				"laptop_monitor_core_lt.png",
+				"laptop_monitor2_core_bk.png",
+				"laptop_monitor2_core_ft_on.png"
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.3125, 0, 0.4375, 0.375, 0.0625}, -- NodeBox1
+					{-0.4375, -0.3125, -0.0625, 0.4375, -0.25, 0}, -- NodeBox2
+					{-0.4375, -0.25, -0.0625, -0.375, 0.3125, 0}, -- NodeBox3
+					{-0.4375, 0.3125, -0.0625, 0.4375, 0.375, 0}, -- NodeBox4
+					{0.375, -0.25, -0.0625, 0.4375, 0.3125, 0}, -- NodeBox5
+					{-0.125, -0.4375, 0, 0.125, -0.3125, 0.0625}, -- NodeBox6
+					{-0.1875, -0.5, -0.0625, 0.1875, -0.4375, 0.125}, -- NodeBox7
+					{-0.5, -0.5, -0.5, 0.25, -0.4375, -0.1875}, -- NodeBox8
+					{0.3125, -0.5, -0.5, 0.5, -0.4375, -0.1875}, -- NodeBox9
+				}
+			}
+		},
+		["off"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_monitor2_core_bt.png",
+				"laptop_laptop_core_bt.png",
+				"laptop_monitor_core_rt.png",
+				"laptop_monitor_core_lt.png",
+				"laptop_monitor2_core_bk.png",
+				"laptop_monitor2_core_ft.png"
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.3125, 0, 0.4375, 0.375, 0.0625}, -- NodeBox1
+					{-0.4375, -0.3125, -0.0625, 0.4375, -0.25, 0}, -- NodeBox2
+					{-0.4375, -0.25, -0.0625, -0.375, 0.3125, 0}, -- NodeBox3
+					{-0.4375, 0.3125, -0.0625, 0.4375, 0.375, 0}, -- NodeBox4
+					{0.375, -0.25, -0.0625, 0.4375, 0.3125, 0}, -- NodeBox5
+					{-0.125, -0.4375, 0, 0.125, -0.3125, 0.0625}, -- NodeBox6
+					{-0.1875, -0.5, -0.0625, 0.1875, -0.4375, 0.125}, -- NodeBox7
+					{-0.5, -0.5, -0.5, 0.25, -0.4375, -0.1875}, -- NodeBox8
+					{0.3125, -0.5, -0.5, 0.5, -0.4375, -0.1875}, -- NodeBox9
+				}
+			}
 		}
 	}
 })
 
-minetest.register_node("laptop:monitor2_on", {
-    description = "MT Desktop 2.0",
-	tiles = {
-		"laptop_monitor2_core_bt.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_monitor_core_rt.png",
-		"laptop_monitor_core_lt.png",
-		"laptop_monitor2_core_bk.png",
-		"laptop_monitor2_core_ft_on.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor2_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:monitor2_off")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:set_theme("red")
-		os:power_on()
-		os:set_infotext('MT Desktop')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.3125, 0, 0.4375, 0.375, 0.0625}, -- NodeBox1
-			{-0.4375, -0.3125, -0.0625, 0.4375, -0.25, 0}, -- NodeBox2
-			{-0.4375, -0.25, -0.0625, -0.375, 0.3125, 0}, -- NodeBox3
-			{-0.4375, 0.3125, -0.0625, 0.4375, 0.375, 0}, -- NodeBox4
-			{0.375, -0.25, -0.0625, 0.4375, 0.3125, 0}, -- NodeBox5
-			{-0.125, -0.4375, 0, 0.125, -0.3125, 0.0625}, -- NodeBox6
-			{-0.1875, -0.5, -0.0625, 0.1875, -0.4375, 0.125}, -- NodeBox7
-			{-0.5, -0.5, -0.5, 0.25, -0.4375, -0.1875}, -- NodeBox8
-			{0.3125, -0.5, -0.5, 0.5, -0.4375, -0.1875}, -- NodeBox9
-		}
-	}
-})
 
-minetest.register_node("laptop:monitor2_off", {
-    description = "MT Desktop 2.0",
-	tiles = {
-		"laptop_monitor2_core_bt.png",
-		"laptop_laptop_core_bt.png",
-		"laptop_monitor_core_rt.png",
-		"laptop_monitor_core_lt.png",
-		"laptop_monitor2_core_bk.png",
-		"laptop_monitor2_core_ft.png"
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor2_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_on("laptop:monitor2_on")
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_off()
-		os:set_infotext('MT Desktop')
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.3125, 0, 0.4375, 0.375, 0.0625}, -- NodeBox1
-			{-0.4375, -0.3125, -0.0625, 0.4375, -0.25, 0}, -- NodeBox2
-			{-0.4375, -0.25, -0.0625, -0.375, 0.3125, 0}, -- NodeBox3
-			{-0.4375, 0.3125, -0.0625, 0.4375, 0.375, 0}, -- NodeBox4
-			{0.375, -0.25, -0.0625, 0.4375, 0.3125, 0}, -- NodeBox5
-			{-0.125, -0.4375, 0, 0.125, -0.3125, 0.0625}, -- NodeBox6
-			{-0.1875, -0.5, -0.0625, 0.1875, -0.4375, 0.125}, -- NodeBox7
-			{-0.5, -0.5, -0.5, 0.25, -0.4375, -0.1875}, -- NodeBox8
-			{0.3125, -0.5, -0.5, 0.5, -0.4375, -0.1875}, -- NodeBox9
-		}
-	}
-})
-
-minetest.register_node("laptop:monitor4_on", {
-    description = "Bell CrossOver",
-	tiles = {
-		"laptop_opti_pc_top.png^laptop_opti_kb_top.png^laptop_opti_ms_top.png^laptop_opti_lcb_top.png^laptop_opti_lcp_top.png^laptop_opti_lcd_top.png",
-		"laptop_opti_pc_bottom.png^laptop_opti_kb_bottom.png^laptop_opti_ms_bottom.png^laptop_opti_lcd_bottom.png",
-		"laptop_opti_pc_right.png^laptop_opti_kb_right.png^laptop_opti_ms_right.png^laptop_opti_lcb_right.png^laptop_opti_lcp_right.png^laptop_opti_lcd_right.png",
-		"laptop_opti_pc_left.png^laptop_opti_kb_left.png^laptop_opti_ms_left.png^laptop_opti_lcb_left.png^laptop_opti_lcp_left.png^laptop_opti_lcd_left.png",
-		"laptop_opti_pc_back.png^laptop_opti_kb_back.png^laptop_opti_ms_back.png^laptop_opti_lcb_back.png^laptop_opti_lcp_back.png^laptop_opti_lcd_back.png",
-		"laptop_opti_pc_on_front.png^laptop_opti_kb_front.png^laptop_opti_ms_front.png^laptop_opti_lcb_front.png^laptop_opti_lcp_front.png^laptop_opti_lcd_on_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor2_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:monitor4_off")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:set_theme("red")
-		os:power_on()
-		os:set_infotext('Bell CrossOver')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.375, -0.5, -0.0625, 0.375, -0.3125, 0.4375}, -- tower
-			{-0.4375, -0.5, -0.4375, 0.25, -0.4375, -0.1875}, -- keboard
-			{0.3125, -0.5, -0.375, 0.4375, -0.4375, -0.1875}, -- mouse
-			{-0.25, -0.3125, 0.0625, 0.25, -0.25, 0.3125}, -- lcd_base
-			{-0.0625, -0.25, 0.1875, 0.0625, 0.0625, 0.25}, -- lcd_pedestal
-			{-0.4375, -0.125, 0.125, 0.4375, 0.4375, 0.1875}, -- lcd_main
-			
-		}
-	}
-})
-
-minetest.register_node("laptop:monitor4_off", {
-    description = "Bell CrossOver",
-	tiles = {
-		"laptop_opti_pc_top.png^laptop_opti_kb_top.png^laptop_opti_ms_top.png^laptop_opti_lcb_top.png^laptop_opti_lcp_top.png^laptop_opti_lcd_top.png",
-		"laptop_opti_pc_bottom.png^laptop_opti_kb_bottom.png^laptop_opti_ms_bottom.png^laptop_opti_lcd_bottom.png",
-		"laptop_opti_pc_right.png^laptop_opti_kb_right.png^laptop_opti_ms_right.png^laptop_opti_lcb_right.png^laptop_opti_lcp_right.png^laptop_opti_lcd_right.png",
-		"laptop_opti_pc_left.png^laptop_opti_kb_left.png^laptop_opti_ms_left.png^laptop_opti_lcb_left.png^laptop_opti_lcp_left.png^laptop_opti_lcd_left.png",
-		"laptop_opti_pc_back.png^laptop_opti_kb_back.png^laptop_opti_ms_back.png^laptop_opti_lcb_back.png^laptop_opti_lcp_back.png^laptop_opti_lcd_back.png",
-		"laptop_opti_pc_front.png^laptop_opti_kb_front.png^laptop_opti_ms_front.png^laptop_opti_lcb_front.png^laptop_opti_lcp_front.png^laptop_opti_lcd_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = "facedir",
-	drop = "laptop:monitor4_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, dig_immediate = 2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_on("laptop:monitor4_on")
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_off()
-		os:set_infotext('Bell CrossOver')
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.375, -0.5, -0.0625, 0.375, -0.3125, 0.4375}, -- tower
-			{-0.4375, -0.5, -0.4375, 0.25, -0.4375, -0.1875}, -- keboard
-			{0.3125, -0.5, -0.375, 0.4375, -0.4375, -0.1875}, -- mouse
-			{-0.25, -0.3125, 0.0625, 0.25, -0.25, 0.3125}, -- lcd_base
-			{-0.0625, -0.25, 0.1875, 0.0625, 0.0625, 0.25}, -- lcd_pedestal
-			{-0.4375, -0.125, 0.125, 0.4375, 0.4375, 0.1875}, -- lcd_main
-			
+laptop.register_hardware("laptop:monitor4", {
+	description = "Bell CrossOver",
+	infotext = "Bell CrossOver",
+	sequence = { "off", "on"},
+	node_defs = {
+		["on"] = {
+			hw_state = "power_on",
+			tiles = {
+				"laptop_opti_pc_top.png^laptop_opti_kb_top.png^laptop_opti_ms_top.png^laptop_opti_lcb_top.png^laptop_opti_lcp_top.png^laptop_opti_lcd_top.png",
+				"laptop_opti_pc_bottom.png^laptop_opti_kb_bottom.png^laptop_opti_ms_bottom.png^laptop_opti_lcd_bottom.png",
+				"laptop_opti_pc_right.png^laptop_opti_kb_right.png^laptop_opti_ms_right.png^laptop_opti_lcb_right.png^laptop_opti_lcp_right.png^laptop_opti_lcd_right.png",
+				"laptop_opti_pc_left.png^laptop_opti_kb_left.png^laptop_opti_ms_left.png^laptop_opti_lcb_left.png^laptop_opti_lcp_left.png^laptop_opti_lcd_left.png",
+				"laptop_opti_pc_back.png^laptop_opti_kb_back.png^laptop_opti_ms_back.png^laptop_opti_lcb_back.png^laptop_opti_lcp_back.png^laptop_opti_lcd_back.png",
+				"laptop_opti_pc_on_front.png^laptop_opti_kb_front.png^laptop_opti_ms_front.png^laptop_opti_lcb_front.png^laptop_opti_lcp_front.png^laptop_opti_lcd_on_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.375, -0.5, -0.0625, 0.375, -0.3125, 0.4375}, -- tower
+					{-0.4375, -0.5, -0.4375, 0.25, -0.4375, -0.1875}, -- keboard
+					{0.3125, -0.5, -0.375, 0.4375, -0.4375, -0.1875}, -- mouse
+					{-0.25, -0.3125, 0.0625, 0.25, -0.25, 0.3125}, -- lcd_base
+					{-0.0625, -0.25, 0.1875, 0.0625, 0.0625, 0.25}, -- lcd_pedestal
+					{-0.4375, -0.125, 0.125, 0.4375, 0.4375, 0.1875}, -- lcd_main
+				}
+			}
+		},
+		["off"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_opti_pc_top.png^laptop_opti_kb_top.png^laptop_opti_ms_top.png^laptop_opti_lcb_top.png^laptop_opti_lcp_top.png^laptop_opti_lcd_top.png",
+				"laptop_opti_pc_bottom.png^laptop_opti_kb_bottom.png^laptop_opti_ms_bottom.png^laptop_opti_lcd_bottom.png",
+				"laptop_opti_pc_right.png^laptop_opti_kb_right.png^laptop_opti_ms_right.png^laptop_opti_lcb_right.png^laptop_opti_lcp_right.png^laptop_opti_lcd_right.png",
+				"laptop_opti_pc_left.png^laptop_opti_kb_left.png^laptop_opti_ms_left.png^laptop_opti_lcb_left.png^laptop_opti_lcp_left.png^laptop_opti_lcd_left.png",
+				"laptop_opti_pc_back.png^laptop_opti_kb_back.png^laptop_opti_ms_back.png^laptop_opti_lcb_back.png^laptop_opti_lcp_back.png^laptop_opti_lcd_back.png",
+				"laptop_opti_pc_front.png^laptop_opti_kb_front.png^laptop_opti_ms_front.png^laptop_opti_lcb_front.png^laptop_opti_lcp_front.png^laptop_opti_lcd_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = "facedir",
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.375, -0.5, -0.0625, 0.375, -0.3125, 0.4375}, -- tower
+					{-0.4375, -0.5, -0.4375, 0.25, -0.4375, -0.1875}, -- keboard
+					{0.3125, -0.5, -0.375, 0.4375, -0.4375, -0.1875}, -- mouse
+					{-0.25, -0.3125, 0.0625, 0.25, -0.25, 0.3125}, -- lcd_base
+					{-0.0625, -0.25, 0.1875, 0.0625, 0.0625, 0.25}, -- lcd_pedestal
+					{-0.4375, -0.125, 0.125, 0.4375, 0.4375, 0.1875}, -- lcd_main
+				}
+			}
 		}
 	}
 })
@@ -383,81 +260,60 @@ minetest.register_craft({
 })
 
 --Old PC--
-minetest.register_node("laptop:monitor3_on", {
-    description = "MT Desktop vintage 3.0",
-	tiles = {
-		"laptop_k_top.png^laptop_t_top.png^laptop_p_top.png^laptop_m_top.png",
-		"laptop_k_bottom.png^laptop_t_bottom.png^laptop_p_bottom.png^laptop_m_bottom.png",
-		"laptop_k_right.png^laptop_t_right.png^laptop_p_right.png^laptop_m_right.png",
-		"laptop_k_left.png^laptop_t_left.png^laptop_p_left.png^laptop_m_left.png",
-		"laptop_k_back.png^laptop_t_back.png^laptop_p_back.png^laptop_m_back.png",
-		"laptop_k_front.png^laptop_t_front_on.png^laptop_p_front.png^laptop_m_front_on.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = 'facedir',
-	drop = "laptop:monitor3_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:monitor3_off")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_on()
-		os:set_infotext('MT Desktop')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.3125, -0.5, -0.5, 0.3125, -0.4375, -0.25}, -- keyboard
-			{-0.4375, -0.5, -0.1875, 0.4375, -0.3125, 0.4375}, -- tower
-			{-0.25, -0.3125, -0.0625, 0.25, -0.25, 0.375}, -- pedestal
-			{-0.375, -0.25, -0.125, 0.375, 0.25, 0.4375}, -- monitor
+laptop.register_hardware("laptop:monitor3", {
+	description = "MT Desktop vintage 3.0",
+	infotext = "MT Desktop vintage 3.0",
+	sequence = { "off", "on"},
+	node_defs = {
+		["on"] = {
+			hw_state = "power_on",
+			tiles = {
+				"laptop_k_top.png^laptop_t_top.png^laptop_p_top.png^laptop_m_top.png",
+				"laptop_k_bottom.png^laptop_t_bottom.png^laptop_p_bottom.png^laptop_m_bottom.png",
+				"laptop_k_right.png^laptop_t_right.png^laptop_p_right.png^laptop_m_right.png",
+				"laptop_k_left.png^laptop_t_left.png^laptop_p_left.png^laptop_m_left.png",
+				"laptop_k_back.png^laptop_t_back.png^laptop_p_back.png^laptop_m_back.png",
+				"laptop_k_front.png^laptop_t_front_on.png^laptop_p_front.png^laptop_m_front_on.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = 'facedir',
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.3125, -0.5, -0.5, 0.3125, -0.4375, -0.25}, -- keyboard
+					{-0.4375, -0.5, -0.1875, 0.4375, -0.3125, 0.4375}, -- tower
+					{-0.25, -0.3125, -0.0625, 0.25, -0.25, 0.375}, -- pedestal
+					{-0.375, -0.25, -0.125, 0.375, 0.25, 0.4375}, -- monitor
+				}
+			}
+		},
+		["off"] = {
+			hw_state = "power_on",
+			tiles = {
+				"laptop_k_top.png^laptop_t_top.png^laptop_p_top.png^laptop_m_top.png",
+				"laptop_k_bottom.png^laptop_t_bottom.png^laptop_p_bottom.png^laptop_m_bottom.png",
+				"laptop_k_right.png^laptop_t_right.png^laptop_p_right.png^laptop_m_right.png",
+				"laptop_k_left.png^laptop_t_left.png^laptop_p_left.png^laptop_m_left.png",
+				"laptop_k_back.png^laptop_t_back.png^laptop_p_back.png^laptop_m_back.png",
+				"laptop_k_front.png^laptop_t_front.png^laptop_p_front.png^laptop_m_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = 'facedir',
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.3125, -0.5, -0.5, 0.3125, -0.4375, -0.25}, -- keyboard
+					{-0.4375, -0.5, -0.1875, 0.4375, -0.3125, 0.4375}, -- tower
+					{-0.25, -0.3125, -0.0625, 0.25, -0.25, 0.375}, -- pedestal
+					{-0.375, -0.25, -0.125, 0.375, 0.25, 0.4375}, -- monitor
+				}
+			}
 		}
 	}
 })
 
-minetest.register_node("laptop:monitor3_off", {
-    description = "MT Desktop vintage 3.0",
-	tiles = {
-		"laptop_k_top.png^laptop_t_top.png^laptop_p_top.png^laptop_m_top.png",
-		"laptop_k_bottom.png^laptop_t_bottom.png^laptop_p_bottom.png^laptop_m_bottom.png",
-		"laptop_k_right.png^laptop_t_right.png^laptop_p_right.png^laptop_m_right.png",
-		"laptop_k_left.png^laptop_t_left.png^laptop_p_left.png^laptop_m_left.png",
-		"laptop_k_back.png^laptop_t_back.png^laptop_p_back.png^laptop_m_back.png",
-		"laptop_k_front.png^laptop_t_front.png^laptop_p_front.png^laptop_m_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = 'facedir',
-	drop = "laptop:monitor3_off",
-	groups = {choppy=2, oddly_breakably_by_hand=2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_on( "laptop:monitor3_on")
-	end,
-	on_construct = function(pos)
-			local meta = minetest.env:get_meta(pos)
-			meta:set_string('infotext', 'MT Desktop')
-		end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.3125, -0.5, -0.5, 0.3125, -0.4375, -0.25}, -- keyboard
-			{-0.4375, -0.5, -0.1875, 0.4375, -0.3125, 0.4375}, -- tower
-			{-0.25, -0.3125, -0.0625, 0.25, -0.25, 0.375}, -- pedestal
-			{-0.375, -0.25, -0.125, 0.375, 0.25, 0.4375}, -- monitor
-		}
-	}
-})
 minetest.register_craft({
 	output = 'laptop:monitor3_off',
 	recipe = {
@@ -466,110 +322,78 @@ minetest.register_craft({
 		{'default:steel_ingot', 'default:glass', 'default:steel_ingot'},
 	}
 })
+
 -- Laptop v2.0
-minetest.register_node("laptop:laptop_closed", {
-    description = "laptop v2.0",
-	tiles = {
-		"laptop_lap_base_closed_top.png",
-		"laptop_lap_base_closed_bottom.png",
-		"laptop_lap_base_closed_right.png",
-		"laptop_lap_base_closed_left.png",
-		"laptop_lap_base_closed_back.png",
-		"laptop_lap_base_closed_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = 'facedir',
-	drop = "laptop:laptop_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:laptop_open")
-	end,
-	on_construct = function(pos)
-			local meta = minetest.env:get_meta(pos)
-			meta:set_string('infotext', 'MT Desktop')
-		end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.375}, -- base_closed
-			
+laptop.register_hardware("laptop:laptop", {
+	description = "laptop v2.0",
+	infotext = "laptop v2.0",
+	sequence = { "closed", "open", "open_on"},
+	node_defs = {
+		["closed"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_lap_base_closed_top.png",
+				"laptop_lap_base_closed_bottom.png",
+				"laptop_lap_base_closed_right.png",
+				"laptop_lap_base_closed_left.png",
+				"laptop_lap_base_closed_back.png",
+				"laptop_lap_base_closed_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = 'facedir',
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.375, 0.375}, -- base_closed
+				}
+			}
+		},
+		["open"] = {
+			hw_state = "power_off",
+			tiles = {
+				"laptop_lap_base_open_top.png",
+				"laptop_lap_base_open_bottom.png^laptop_lap_sc_open_bottom.png",
+				"laptop_lap_base_open_right.png",
+				"laptop_lap_base_open_left.png",
+				"laptop_lap_base_open_back.png^laptop_lap_sc_open_back.png",
+				"laptop_lap_base_open_front.png^laptop_lap_sc_open_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = 'facedir',
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.4375, 0.375}, -- base_open
+					{-0.4375, -0.4375, 0.375, 0.4375, 0.3125, 0.4375}, -- sc_open
+				}
+			}
+		},
+		["open_on"] = {
+			hw_state = "resume",
+			tiles = {
+				"laptop_lap_base_open_on_top.png",
+				"laptop_lap_base_open_bottom.png^laptop_lap_sc_open_bottom.png",
+				"laptop_lap_base_open_right.png",
+				"laptop_lap_base_open_left.png",
+				"laptop_lap_base_open_back.png^laptop_lap_sc_open_back.png",
+				"laptop_lap_base_open_front.png^laptop_lap_sc_open_on_front.png",
+			},
+			drawtype = "nodebox",
+			paramtype = "light",
+			paramtype2 = 'facedir',
+			node_box = {
+				type = "fixed",
+				fixed = {
+					{-0.4375, -0.5, -0.4375, 0.4375, -0.4375, 0.375}, -- base_open
+					{-0.4375, -0.4375, 0.375, 0.4375, 0.3125, 0.4375}, -- sc_open
+				}
+			}
 		}
 	}
 })
-minetest.register_node("laptop:laptop_open", {
-    description = "laptop v2.0",
-	tiles = {
-		"laptop_lap_base_open_top.png",
-		"laptop_lap_base_open_bottom.png^laptop_lap_sc_open_bottom.png",
-		"laptop_lap_base_open_right.png",
-		"laptop_lap_base_open_left.png",
-		"laptop_lap_base_open_back.png^laptop_lap_sc_open_back.png",
-		"laptop_lap_base_open_front.png^laptop_lap_sc_open_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = 'facedir',
-	drop = "laptop:laptop_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:resume("laptop:laptop_open_on")
-	end,
-	on_construct = function(pos)
-			local meta = minetest.env:get_meta(pos)
-			meta:set_string('infotext', 'MT Desktop')
-		end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.4375, 0.375}, -- base_open
-			{-0.4375, -0.4375, 0.375, 0.4375, 0.3125, 0.4375}, -- sc_open
-			
-		}
-	}
-})
-minetest.register_node("laptop:laptop_open_on", {
-    description = "laptop v2.0",
-	tiles = {
-		"laptop_lap_base_open_on_top.png",
-		"laptop_lap_base_open_bottom.png^laptop_lap_sc_open_bottom.png",
-		"laptop_lap_base_open_right.png",
-		"laptop_lap_base_open_left.png",
-		"laptop_lap_base_open_back.png^laptop_lap_sc_open_back.png",
-		"laptop_lap_base_open_front.png^laptop_lap_sc_open_on_front.png",
-	},
-	drawtype = "nodebox",
-	paramtype = "light",
-	paramtype2 = 'facedir',
-	drop = "laptop:laptop_closed",
-	groups = {choppy=2, oddly_breakably_by_hand=2, not_in_creative_inventory=1},
-	on_punch = function (pos, node, puncher)
-		local os = laptop.os_get(pos)
-		os:power_off("laptop:laptop_closed")
-	end,
-	on_construct = function(pos)
-		local os = laptop.os_get(pos)
-		os:power_on()
-		os:set_infotext('MineTest Core')
-	end,
-	after_place_node = laptop.after_place_node,
-	after_dig_node = laptop.after_dig_node,
-	stack_max = 1,
-	on_receive_fields = function(pos, formname, fields, sender)
-		local os = laptop.os_get(pos)
-		os:receive_fields(fields, sender)
-	end,
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.4375, -0.5, -0.4375, 0.4375, -0.4375, 0.375}, -- base_open
-			{-0.4375, -0.4375, 0.375, 0.4375, 0.3125, 0.4375}, -- sc_open
-			
-		}
-	}
-})
+
 minetest.register_craft({
 	output = 'laptop:laptop_closed',
 	recipe = {
@@ -578,3 +402,4 @@ minetest.register_craft({
 		{'default:steel_ingot', 'default:glass', 'default:steel_ingot'},
 	}
 })
+

--- a/os.lua
+++ b/os.lua
@@ -120,33 +120,3 @@ function laptop.os_get(pos)
 	self.theme = self:get_theme()
 	return self
 end
-
------------------------------------------------------
--- Hooks for node definition
------------------------------------------------------
-function laptop.after_place_node(pos, placer, itemstack, pointed_thing)
-	local appdata = minetest.deserialize(itemstack:get_meta():get_string("laptop_appdata"))
-	if appdata then
-		local os = laptop.os_get(pos)
-		os.appdata = appdata
-		os.appdata.launcher = os.appdata.launcher or {}
-		os.appdata.os = os.appdata.os or {}
-		os:save()
-	end
-end
-
-function laptop.after_dig_node(pos, oldnode, oldmetadata, digger)
-	local appdata = oldmetadata.fields['laptop_appdata']
-	if appdata then
-		local item_name = minetest.registered_items[oldnode.name].drop or oldnode.name
-		local inventory = digger:get_inventory()
-		for idx = inventory:get_size("main"), 1, -1 do
-			local stack = inventory:get_stack("main", idx)
-			if stack:get_name() == item_name and stack:get_meta():get_string("laptop_appdata") == "" then
-				stack:get_meta():set_string("laptop_appdata", appdata)
-				digger:get_inventory():set_stack("main", idx, stack)
-				break
-			end
-		end
-	end
-end


### PR DESCRIPTION
Please check / test my changes before merging. This change was needed to be more flexible in feature. Like if I need "allow_metadata_inventory_move" for example in feature on all supported nodes I just need to enhance the framework.

All computers merged to this framework already. Please note something is wrong with laptop_opti textures..