### PR TITLE
More theme framework

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,8 +113,9 @@ Definitiontable:
 
 ### Theme methods
 `function laptop.get_theme(theme_name)`
-- `theme:get_button(area, prefix, code, text)` get a themed [prefix]_button in area 'x,y;w,h' with code an text
-- `theme:get_label(pos, text)` get a themed label text starting at pos 'x,y'
+- `theme:get_button(area, prefix, code, text)` get a themed [prefix]_button in area 'x,y;w,h' with code and text
+- `theme:get_image_button(area, prefix, code, image, text)` get a themed [prefix]_button in area 'x,y;w,h' with code an image and text. Text is colorized by [prefix]_textcolor or textcolor
+- `theme:get_label(pos, text, color_prefix)` get a themed label text starting at pos 'x,y', colorize theme by color prefix (usually the button text colors)
 
 
 ## Block devices / Data objects

--- a/apps/launcher_app.lua
+++ b/apps/launcher_app.lua
@@ -39,9 +39,8 @@ laptop.register_app("launcher", {
 		for i, e in ipairs(appslist_sorted) do
 			local x = math.floor((i-1) / c_row_count)*2 + 1
 			local y = ((i-1) % c_row_count)*2 + 1
-			out = out .. 'image_button['..x..','..y..';1,1;'..mtos.theme.app_button..'^'..(e.def.app_icon or 'logo.png')..';'..e.name..';]'..
-						'label['..(x-0.3)..','..(y+1)..';'..e.def.app_name..']'..
-						'tooltip['..e.name..';'..(e.def.app_info or e.name)..']'    --;<bgcolor>;<fontcolor>]'
+			out = out .. mtos.theme:get_image_button(x..','..y..';1,1', 'app', e.name, (e.def.app_icon or 'logo.png'), "", (e.def.app_info or e.name))..
+						mtos.theme:get_label((x-0.3)..','..(y+1), e.def.app_name, "app")
 		end
 		out = out..mtos.theme:get_button("11,9.8;4,0.7", "major", "os_clock", os.date("%c"))
 		return out
@@ -52,7 +51,7 @@ laptop.register_app("launcher", {
 			formspec = formspec..'background[0,0;15,10;'..mtos.theme.app_bg..';true]'
 		end
 		if #mtos.sysram.stack > 0 then
-			formspec = formspec..'image_button[-0.29,-0.31;1.09,0.61;'..mtos.theme.back_button..';os_back;<]'
+			formspec = formspec..mtos.theme:get_button('-0.29,-0.31;1.09,0.61', 'back', 'os_back', '<', 'Return to previous screen')
 		end
 		if app.app_info then
 			if #mtos.sysram.stack > 0 then
@@ -61,7 +60,7 @@ laptop.register_app("launcher", {
 				formspec = formspec.."label[-0.1,-0.29;"..app.app_info.."]"
 			end
 		end
-		formspec = formspec..'image_button[14.2,-0.31;1.09,0.61;'..mtos.theme.exit_button..';os_exit;X]'
+		formspec = formspec..mtos.theme:get_button('14.2,-0.31;1.09,0.61', 'exit', 'os_exit', 'X', 'Exit app')
 		return formspec
 	end,
 	receive_fields_func = function(launcher_app, mtos, sender, fields)

--- a/apps/mail_app.lua
+++ b/apps/mail_app.lua
@@ -25,8 +25,8 @@ laptop.register_app("mail", {
 		account.selected_index = nil -- will be new determinated by selectedmessage
 		local box = account[account.selected_box] -- inbox or outbox
 
+		app.app_info = app.app_info.." - Welcome "..mtos.sysram.last_player.."]"
 		local formspec =
-				"label[4,-0.31;Welcome "..mtos.sysram.last_player.."]"..
 				"tablecolumns[" ..
 						"image,align=center,1=laptop_mail.png,2=laptop_mail_read.png;"..  --icon column
 						"color;"..	-- subject and date color
@@ -84,26 +84,26 @@ laptop.register_app("mail", {
 
 		-- toggle inbox/sentbox
 		if account.selected_box == "inbox" then
-			formspec = formspec .. "image_button[0,9;1,1;"..mtos.theme.minor_button.."^laptop_mail_sentbox.png;switch_sentbox;]tooltip[switch_sentbox;Show sent messages]"
+			formspec = formspec .. mtos.theme:get_image_button('0,9;1,1', 'minor', 'switch_sentbox', 'laptop_mail_sentbox.png', '', 'Show sent messages')
 		else
-			formspec = formspec .. "image_button[0,9;1,1;"..mtos.theme.minor_button.."^laptop_mail_received.png;switch_inbox;]tooltip[switch_inbox;Show received messages]"
+			formspec = formspec .. mtos.theme:get_image_button('0,9;1,1', 'minor', 'switch_inbox', 'laptop_mail_received.png', '', 'Show received messages')
 		end
 
-		formspec = formspec .. "image_button[1.7,9;1,1;"..mtos.theme.minor_button.."^laptop_email_new.png;new;]tooltip[new;New message]"
+		formspec = formspec .. mtos.theme:get_image_button('1.7,9;1,1', 'minor', 'new', 'laptop_email_new.png', '', 'New message')
 		if account.newmessage then
-			formspec = formspec .. "image_button[2.7,9;1,1;"..mtos.theme.minor_button.."^laptop_email_edit.png;continue;]tooltip[continue;Continue last message]"
+			formspec = formspec .. mtos.theme:get_image_button('2.7,9;1,1', 'minor', 'continue', 'laptop_email_edit.png', '', 'Continue last message')
 		end
 
 		if account.selectedmessage then
 			formspec = formspec ..
-					"image_button[3.7,9;1,1;"..mtos.theme.minor_button.."^laptop_email_reply.png;reply;]tooltip[reply;Reply]"..
-					"image_button[4.7,9;1,1;"..mtos.theme.minor_button.."^laptop_email_forward.png;forward;]tooltip[forward;Forward]"..
-					"image_button[5.7,9;1,1;"..mtos.theme.minor_button.."^laptop_email_trash.png;delete;]tooltip[delete;Delete]"
+					mtos.theme:get_image_button('3.7,9;1,1', 'minor', 'reply', 'laptop_email_reply.png', '', 'Reply')..
+					mtos.theme:get_image_button('4.7,9;1,1', 'minor', 'forward', 'laptop_email_forward.png', '', 'Forward')..
+					mtos.theme:get_image_button('5.7,9;1,1', 'minor', 'delete', 'laptop_email_trash.png', '', 'Delete')
 			if account.selected_box == "inbox" then
 				if not account.selectedmessage.is_read then
-					formspec = formspec .. "image_button[6.7,9;1,1;"..mtos.theme.minor_button.."^laptop_mail_read_button.png;markread;]tooltip[markread;Mark message as read]"
+					formspec = formspec .. mtos.theme:get_image_button('6.7,9;1,1', 'minor', 'markread', 'laptop_mail_read_button.png', '', 'Mark message as read')
 				else
-					formspec = formspec .. "image_button[6.7,9;1,1;"..mtos.theme.minor_button.."^laptop_mail_button.png;markunread;]tooltip[markunread;Mark message as unread]"
+					formspec = formspec .. mtos.theme:get_image_button('6.7,9;1,1', 'minor', 'markunread', 'laptop_mail_button.png', '', 'Mark message as unread')
 				end
 			end
 			if account.selected_box == "inbox" then

--- a/apps/removable_app.lua
+++ b/apps/removable_app.lua
@@ -15,7 +15,7 @@ laptop.register_app("removable", {
 		local idata = mtos.bdev:get_removable_disk()
 		if idata.stack then
 			-- change label
-			formspec = formspec .. mtos.theme:get_label('0,1.2', idata.def.description).."field[2,0.7;4,1;label;Label:;"..idata.label.."]"..
+			formspec = formspec .. mtos.theme:get_label('0,1.2', idata.def.description).."field[2,0.7;4,1;label;;"..idata.label.."]"..
 					mtos.theme:get_button('5.7,0.55;1.5,0.7', 'minor', 'set_label', 'Rename', 'Rename the '..idata.def.description)..
 					mtos.theme:get_label('0,1.7', "Format: "..idata.os_format).. -- format state
 			-- buttons

--- a/themes.lua
+++ b/themes.lua
@@ -35,9 +35,13 @@ theme_class.__index = theme_class
 
 -- get prepared button textures
 function theme_class:get_button(area, prefix, code, text, tooltip)
-	return'image_button['..area..';'..self[prefix.."_button"]..';'..code..';'.. minetest.colorize(self[prefix.."_textcolor"] or self.textcolor,minetest.formspec_escape(text))..']'..
-			"tooltip["..code..";"..minetest.formspec_escape(tooltip or text).."]"
+	local formspec = 'image_button['..area..';'..self[prefix.."_button"]..';'..code..';'.. minetest.colorize(self[prefix.."_textcolor"] or self.textcolor,minetest.formspec_escape(text))..']'
+	if tooltip then
+		formspec = formspec.."tooltip["..code..";"..minetest.formspec_escape(tooltip).."]"
+	end
+	return formspec
 end
+
 -- Get themed label
 function theme_class:get_label(area, label)
 	return'label['..area..';'..minetest.colorize(self.textcolor, minetest.formspec_escape(label))..']'

--- a/themes.lua
+++ b/themes.lua
@@ -7,6 +7,9 @@ laptop.themes = {
 		back_button = "laptop_theme_freedom_back_button.png",
 		exit_button = "laptop_theme_freedom_exit_button.png",
 		app_button = "laptop_theme_freedom_app_button.png",
+		back_textcolor = "#FFFF00",
+		exit_textcolor = "#FF0000",
+		app_textcolor = '#FFFFFF',
 		textcolor = "#000000",
 		node_color = 0,
 		contrast_bg = "gui_formbg.png",
@@ -42,9 +45,23 @@ function theme_class:get_button(area, prefix, code, text, tooltip)
 	return formspec
 end
 
+-- get prepared button textures
+function theme_class:get_image_button(area, prefix, code, image, text, tooltip)
+	local formspec = 'image_button['..area..';'..self[prefix.."_button"]..'^'..image..';'..code..';'.. minetest.colorize(self[prefix.."_textcolor"] or self.textcolor,minetest.formspec_escape(text))..']'
+	if tooltip then
+		formspec = formspec.."tooltip["..code..";"..minetest.formspec_escape(tooltip).."]"
+	end
+	return formspec
+end
+
+
 -- Get themed label
-function theme_class:get_label(area, label)
-	return'label['..area..';'..minetest.colorize(self.textcolor, minetest.formspec_escape(label))..']'
+function theme_class:get_label(area, label, color_prefix)
+	if color_prefix then
+		return 'label['..area..';'..minetest.colorize(self[color_prefix.."_textcolor"] or self.textcolor, minetest.formspec_escape(label))..']'
+	else
+		return 'label['..area..';'..minetest.colorize(self.textcolor, minetest.formspec_escape(label))..']'
+	end
 end
 
 function laptop.get_theme(theme_name)

--- a/themes/bubbles_theme.lua
+++ b/themes/bubbles_theme.lua
@@ -6,4 +6,5 @@ laptop.register_theme("Bubbles", {
 	back_button = "laptop_theme_blue_back_button.png",
 	exit_button = "laptop_theme_blue_exit_button.png",
 	app_button = "laptop_theme_blue_app_button.png",
+	app_textcolor = "#0000FF",
 })


### PR DESCRIPTION
More usage for theme framework.
back-button is now with yellow "<", the exit with red "X".
Bubble theme does have blue app name text in launcher because the white was to white.
Optimizations for buttons, fixed issue with wrong tooltipps in calculator